### PR TITLE
cleanup old test files

### DIFF
--- a/client/src/__testUtils__/fetchMocks.js
+++ b/client/src/__testUtils__/fetchMocks.js
@@ -1,3 +1,0 @@
-export const asSlowResponse = (response) => {
-  return () => new Promise((resolve) => setTimeout(() => resolve(response)));
-};

--- a/client/src/pages/User/__tests__/UserList.test.js
+++ b/client/src/pages/User/__tests__/UserList.test.js
@@ -13,7 +13,14 @@ import {
   getUsersSuccessMock,
   getUsersFailedMock,
 } from "../../../__testUtils__/fetchUserMocks";
-import { asSlowResponse } from "../../../__testUtils__/fetchMocks";
+
+const asSlowResponse = (res) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(res);
+    }, 300);
+  });
+};
 
 beforeEach(() => {
   fetch.resetMocks();


### PR DESCRIPTION
What I did:

    Removed src/__testUtils__/fetchMocks.js
    - The only function inside it (asSlowResponse) was used in one place, so I moved it directly into UserList.test.js.

Questions for the team:

    -Do we want to delete src/util/__tests__/createTestIdFilePath.test.js?
    It only tests a basic join("/") function. 

    -src/util/validateAllowedFields.js contains helper functions for Zod schema validation,
    but they’re not used anywhere in the code right now.
    -Should we remove it now, or keep it in case we plan to use it for request validation in the future