### PR TITLE
fix: desc line clamp

### DIFF
--- a/client/src/components/Deck.jsx
+++ b/client/src/components/Deck.jsx
@@ -31,7 +31,7 @@ const Deck = ({ deckID, title, description, user, numCards, className }) => {
         <Chip>{numCards} Cards</Chip>
       </CardHeader>
       <CardBody>
-        <p>{description}</p>
+        <p className="line-clamp-3">{description}</p>
       </CardBody>
       <CardFooter className="justify-between">
         <div className="flex gap-3">

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -53,4 +53,11 @@
   .animate-marquee-vertical {
     animation: marquee-vertical var(--duration) linear infinite;
   }
+
+  .line-clamp-3 {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
 }


### PR DESCRIPTION
- Added Tailwind utility .line-clamp-3 in client/src/index.css for multi-line truncation of text.

- Applied line-clamp-3 to deck card descriptions in client/src/components/Deck.jsx to prevent overflow.
<img width="1081" height="739" alt="image" src="https://github.com/user-attachments/assets/48164957-366d-4cdb-910c-7f1e3c14c1ad" />

<img width="1911" height="707" alt="image" src="https://github.com/user-attachments/assets/cfad4361-d3a9-4137-82a5-ca58d2cf2f3e" />

