### PR TITLE
fixed refresh access token bug

### DIFF
--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -27,7 +27,7 @@ const apiRequest = async (
     const response = await fetch(`/api${endpoint}`, options);
 
     // if token is expired, refresh it and retry the request
-    if (response.status === 403) {
+    if (response.status === 401) {
       const newTokens = await refreshAccessToken(user?.refreshToken);
 
       if (newTokens) {

--- a/client/src/pages/User/UserProfile.jsx
+++ b/client/src/pages/User/UserProfile.jsx
@@ -131,7 +131,7 @@ const UserProfile = () => {
         <Title
           breadcrumbs={[
             { label: "Home", path: "/" },
-            { label: "Profile", path: `/users/${userInfo.id}` },
+            { label: "Profile", path: `/users/me` },
           ]}
         >
           Profile

--- a/client/src/provider/UserProvider.jsx
+++ b/client/src/provider/UserProvider.jsx
@@ -17,19 +17,23 @@ export default function UserProvider({ children }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const getLocalStorageUser = localStorage.getItem("user");
-    if (getLocalStorageUser) {
-      const localUser = JSON.parse(getLocalStorageUser);
-      const refreshUserToken = refreshToken(localUser);
-      setUser({
-        userid: refreshUserToken.userid || "",
-        username: refreshUserToken.username || "",
-        profilePictureUrl: refreshUserToken.profilePictureUrl || "",
-        accessToken: refreshUserToken.accessToken || "",
-        refreshToken: refreshUserToken.refreshToken || "",
-      });
-    }
-    setIsUserLoaded(true);
+    const initializeUser = async () => {
+      const getLocalStorageUser = localStorage.getItem("user");
+      if (getLocalStorageUser) {
+        const localUser = JSON.parse(getLocalStorageUser);
+        const refreshUserToken = await refreshToken(localUser);
+        setUser({
+          userid: refreshUserToken.userid || "",
+          username: refreshUserToken.username || "",
+          profilePictureUrl: refreshUserToken.profilePictureUrl || "",
+          accessToken: refreshUserToken.accessToken || "",
+          refreshToken: refreshUserToken.refreshToken || "",
+        });
+      }
+      setIsUserLoaded(true);
+    };
+
+    initializeUser();
   }, []);
 
   const setLocalStorageUser = (userData) => {
@@ -75,9 +79,10 @@ export default function UserProvider({ children }) {
 
   const refreshToken = async (activeUser) => {
     try {
-      const newTokens = await refreshAccessToken(activeUser.refreshToken);
-      if (newTokens) {
-        setLocalStorageUser(newTokens);
+      const refreshUserInfo = await refreshAccessToken(activeUser.refreshToken);
+      if (refreshUserInfo) {
+        setLocalStorageUser(refreshUserInfo);
+        return refreshUserInfo;
       }
     } catch {
       addToast({

--- a/client/src/provider/UserProvider.jsx
+++ b/client/src/provider/UserProvider.jsx
@@ -20,12 +20,13 @@ export default function UserProvider({ children }) {
     const getLocalStorageUser = localStorage.getItem("user");
     if (getLocalStorageUser) {
       const localUser = JSON.parse(getLocalStorageUser);
+      const refreshUserToken = refreshToken(localUser);
       setUser({
-        userid: localUser.userid || "",
-        username: localUser.username || "",
-        profilePictureUrl: localUser.profilePictureUrl || "",
-        accessToken: localUser.accessToken || "",
-        refreshToken: localUser.refreshToken || "",
+        userid: refreshUserToken.userid || "",
+        username: refreshUserToken.username || "",
+        profilePictureUrl: refreshUserToken.profilePictureUrl || "",
+        accessToken: refreshUserToken.accessToken || "",
+        refreshToken: refreshUserToken.refreshToken || "",
       });
     }
     setIsUserLoaded(true);
@@ -72,9 +73,9 @@ export default function UserProvider({ children }) {
     navigate(ROUTES.HOME);
   };
 
-  const refreshToken = async () => {
+  const refreshToken = async (activeUser) => {
     try {
-      const newTokens = await refreshAccessToken(user.refreshToken);
+      const newTokens = await refreshAccessToken(activeUser.refreshToken);
       if (newTokens) {
         setLocalStorageUser(newTokens);
       }

--- a/server/src/middlewares/auth.js
+++ b/server/src/middlewares/auth.js
@@ -16,7 +16,7 @@ export const authenticate = (req, res, next) => {
     next();
   } catch (err) {
     return next(
-      createAndThrowError(HTTP_STATUS.FORBIDDEN, "Invalid or expired token"),
+      createAndThrowError(HTTP_STATUS.UNAUTHORIZED, "Invalid or expired token"),
     );
   }
 };

--- a/server/src/users/user.service.js
+++ b/server/src/users/user.service.js
@@ -91,14 +91,13 @@ class UserService {
     }
 
     const newAccessToken = generateAccessToken(user);
-    const newRefreshToken = generateRefreshToken(user._id);
 
     return {
       userid: user._id,
       username: user.username,
       profilePictureUrl: user.profilePictureUrl || "",
       accessToken: newAccessToken,
-      refreshToken: newRefreshToken,
+      refreshToken: token,
     };
   }
 

--- a/server/src/util/authUtils.js
+++ b/server/src/util/authUtils.js
@@ -17,11 +17,19 @@ export const generateRefreshToken = (user) => {
 };
 
 export const verifyAccessToken = (token) => {
-  return jwt.verify(token, ACCESS_SECRET);
+  try {
+    return jwt.verify(token, ACCESS_SECRET);
+  } catch {
+    return false;
+  }
 };
 
 export const verifyRefreshToken = (token) => {
-  return jwt.verify(token, REFRESH_SECRET);
+  try {
+    return jwt.verify(token, REFRESH_SECRET);
+  } catch {
+    return false;
+  }
 };
 
 export const decodedToken = (token) => {


### PR DESCRIPTION
This pull request focuses on improving authentication and token refresh handling across both the client and server. The main changes include standardizing HTTP status codes for unauthorized access, refining the token refresh logic, and improving token verification error handling.

**Authentication and Authorization Improvements**
- Standardized the HTTP status code for invalid or expired tokens from 403 Forbidden to 401 Unauthorized in both the server middleware and client API request logic to ensure consistent handling of authentication failures. [[1]](diffhunk://#diff-9a23f99f3908a5c0b79bdb6d3bafa84d81f4d1f455e08ed71ecec3535c7a4f4dL19-R19) [[2]](diffhunk://#diff-717e0b88e7596d4f99008a8921b55cc50c523ca23d50462c68129c5533439e76L30-R30)

**Token Refresh Logic Enhancements**
- Updated the user provider logic in `UserProvider.jsx` to use the latest tokens when restoring the user from local storage by invoking the `refreshToken` function with the current user, ensuring user state is always initialized with valid tokens. [[1]](diffhunk://#diff-c6d556060d43c07324bdb7f41672f70025ff9b808b170888ca83c4310db339faR23-R29) [[2]](diffhunk://#diff-c6d556060d43c07324bdb7f41672f70025ff9b808b170888ca83c4310db339faL75-R78)
- Modified the token returned by the `UserService` on the server to use the existing refresh token instead of generating a new one, preventing unnecessary refresh token churn.

**Token Verification Robustness**
- Improved error handling in token verification functions by catching verification errors and returning `false` instead of throwing, making the authentication flow more resilient to invalid tokens.

**User Interface Consistency**
- Updated the user profile breadcrumb path to use `/users/me` instead of a user ID, aligning the frontend with RESTful conventions for the current user's profile.